### PR TITLE
Digitalocean api v2

### DIFF
--- a/libcloud/common/base.py
+++ b/libcloud/common/base.py
@@ -149,7 +149,7 @@ class Response(object):
         :rtype: ``bool``
         :return: ``True`` or ``False``
         """
-        return self.status in [httplib.OK, httplib.CREATED]
+        return self.status in [httplib.OK, httplib.CREATED, httplib.ACCEPTED]
 
     def _decompress_response(self, body, headers):
         """

--- a/libcloud/compute/drivers/digitalocean.py
+++ b/libcloud/compute/drivers/digitalocean.py
@@ -439,7 +439,7 @@ class DigitalOcean2NodeDriver(NodeDriver):
                     private_ips.append(ip)
             else:
                     public_ips.append(ip)
-        extra_keys = ['name', 'image', 'backup_ids', 'features']
+        extra_keys = ['created_at', 'disk', 'kernel', 'memory', 'size', 'name', 'image', 'backup_ids', 'features']
         extra = {}
         for key in extra_keys:
             if key in data:

--- a/libcloud/compute/drivers/digitalocean.py
+++ b/libcloud/compute/drivers/digitalocean.py
@@ -58,7 +58,7 @@ class SSHKey(object):
                 (self.id, self.name, self.pub_key))
 
 
-class DigitalOceanConnection(ConnectionUserAndKey):
+class DigitalOceanFirstGenConnection(ConnectionUserAndKey):
     """
     Connection class for the DigitalOcean driver.
     """
@@ -78,12 +78,12 @@ class DigitalOceanConnection(ConnectionUserAndKey):
         return params
 
 
-class DigitalOceanNodeDriver(NodeDriver):
+class DigitalOceanFirstGenNodeDriver(NodeDriver):
     """
     DigitalOceanNode node driver.
     """
 
-    connectionCls = DigitalOceanConnection
+    connectionCls = DigitalOceanFirstGenConnection
 
     type = Provider.DIGITAL_OCEAN
     name = 'Digital Ocean'
@@ -253,7 +253,7 @@ class DigitalOceanNodeDriver(NodeDriver):
                       pub_key=data.get('ssh_pub_key', None))
 
 
-class DigitalOcean2Connection(ConnectionUserAndKey):
+class DigitalOceanConnection(ConnectionUserAndKey):
     """
     Connection class for the DigitalOcean driver.
     """
@@ -270,12 +270,12 @@ class DigitalOcean2Connection(ConnectionUserAndKey):
         return headers
 
 
-class DigitalOcean2NodeDriver(NodeDriver):
+class DigitalOceanNodeDriver(NodeDriver):
     """
     DigitalOceanNode node driver.
     """
 
-    connectionCls = DigitalOcean2Connection
+    connectionCls = DigitalOceanConnection
 
     type = Provider.DIGITAL_OCEAN
     name = 'Digital Ocean'
@@ -294,7 +294,7 @@ class DigitalOcean2NodeDriver(NodeDriver):
 
         """
 
-        super(DigitalOcean2NodeDriver, self).__init__(key=key, **kwargs)
+        super(DigitalOceanNodeDriver, self).__init__(key=key, **kwargs)
         self.connection.request_path = '/v2'
         self.connection.secret = key
 

--- a/libcloud/compute/drivers/digitalocean.py
+++ b/libcloud/compute/drivers/digitalocean.py
@@ -277,7 +277,7 @@ class DigitalOcean2NodeDriver(NodeDriver):
 
     connectionCls = DigitalOcean2Connection
 
-    type = Provider.DIGITAL_OCEAN2
+    type = Provider.DIGITAL_OCEAN
     name = 'Digital Ocean'
     website = 'https://www.digitalocean.com'
 

--- a/libcloud/compute/drivers/digitalocean.py
+++ b/libcloud/compute/drivers/digitalocean.py
@@ -27,7 +27,7 @@ from libcloud.common.base import ConnectionUserAndKey, JsonResponse
 from libcloud.compute.types import Provider, NodeState, InvalidCredsError
 from libcloud.compute.base import NodeDriver
 from libcloud.compute.base import Node, NodeImage, NodeSize, NodeLocation
-
+from libcloud.utils.networking import is_private_subnet
 
 class DigitalOceanResponse(JsonResponse):
     def parse_error(self):
@@ -77,15 +77,6 @@ class DigitalOceanConnection(ConnectionUserAndKey):
         params['api_key'] = self.key
         return params
 
-    def add_default_headers(self, headers):
-        """
-        Add parameters that are necessary for every request
-        """
-        #assume v2
-        if not self.key:
-            headers['Authorization'] = "Bearer %s" % self.secret
-        return headers
-
 
 class DigitalOceanNodeDriver(NodeDriver):
     """
@@ -101,29 +92,6 @@ class DigitalOceanNodeDriver(NodeDriver):
     NODE_STATE_MAP = {'new': NodeState.PENDING,
                       'off': NodeState.UNKNOWN,
                       'active': NodeState.RUNNING}
-
-    def __init__(self, key, secret=None, **kwargs):
-        """
-        Supports Digital Ocean API versions v1 and v2
-        v1 needs Client ID and API Key, while v2 needs API Key only
-
-        Eg these will try v1
-        driver = get_driver('digitalocean')
-        conn = driver('248395230482583656845e3f08', '4hd93457398r944aa3546')
-        conn = driver(key='2483956845e3f08', secret='4hd44aa3546')
-
-        while this will try v2
-        conn = driver('38379379853973y3492095e45e3f08')
-
-        """
-
-        super(DigitalOceanNodeDriver, self).__init__(key=key,
-                                                     secret=secret, **kwargs)
-        #assume v2
-        if not secret:
-            self.connection.key = ''
-            self.connection.secret = key
-            self.connection.request_path = '/v2'
 
     def list_nodes(self):
         data = self.connection.request('/droplets').object['droplets']
@@ -158,7 +126,7 @@ class DigitalOceanNodeDriver(NodeDriver):
 
         if ex_ssh_key_ids:
             params['ssh_key_ids'] = ','.join(ex_ssh_key_ids)
-        private_networking = kwargs.get('private_networking', False)
+        private_networking = kwargs.get('private_networking', True)
         params['private_networking'] = private_networking
         data = self.connection.request('/droplets/new', params=params).object
         if data.get('status') == 'ERROR':
@@ -283,3 +251,230 @@ class DigitalOceanNodeDriver(NodeDriver):
     def _to_ssh_key(self, data):
         return SSHKey(id=data['id'], name=data['name'],
                       pub_key=data.get('ssh_pub_key', None))
+
+
+class DigitalOcean2Connection(ConnectionUserAndKey):
+    """
+    Connection class for the DigitalOcean driver.
+    """
+
+    host = 'api.digitalocean.com'
+    responseCls = DigitalOceanResponse
+
+    def add_default_headers(self, headers):
+        """
+        Add parameters that are necessary for every request
+        """
+
+        headers['Authorization'] = "Bearer %s" % self.secret
+        return headers
+
+
+class DigitalOcean2NodeDriver(NodeDriver):
+    """
+    DigitalOceanNode node driver.
+    """
+
+    connectionCls = DigitalOcean2Connection
+
+    type = Provider.DIGITAL_OCEAN2
+    name = 'Digital Ocean'
+    website = 'https://www.digitalocean.com'
+
+    NODE_STATE_MAP = {'new': NodeState.PENDING,
+                      'off': NodeState.UNKNOWN,
+                      'active': NodeState.RUNNING}
+
+    def __init__(self, key, **kwargs):
+        """
+        Supports Digital Ocean API version v2
+
+        driver = get_driver('digitalocean2')
+        conn = driver('38315379853973y3492095e45e3f08')
+
+        """
+
+        super(DigitalOcean2NodeDriver, self).__init__(key=key, **kwargs)
+        self.connection.request_path = '/v2'
+        self.connection.secret = key
+
+    def list_nodes(self):
+        data = self.connection.request('/droplets').object['droplets']
+        return list(map(self._to_node, data))
+
+    def list_locations(self, available=True):
+        """
+        List locations
+
+        If available is True, show only locations which are available
+        """
+        locations = []
+        data = self.connection.request('/regions').object['regions']
+
+        for location in data:
+            if available:
+                if location.get('available'):
+                    locations.append(self._to_location(location))
+            else:
+                locations.append(self._to_location(location))
+        return locations
+
+    def list_images(self):
+        data = self.connection.request('/images?per_page=100').object['images']
+        return list(map(self._to_image, data))
+
+    def list_sizes(self):
+        data = self.connection.request('/sizes').object['sizes']
+        return list(map(self._to_size, data))
+
+    def create_node(self, name, size, image, location, ex_ssh_key_ids=None,
+                    **kwargs):
+        """
+        Create a node.
+
+        :keyword    ex_ssh_key_ids: A list of ssh key ids which will be added
+                                   to the server. (optional)
+        :type       ex_ssh_key_ids: ``list`` of ``str``
+
+        :return: The newly created node.
+        :rtype: :class:`Node`
+        """
+        params = {'name': name, 'size': size.id, 'image': image.id,
+                  'region': location.id}
+
+        if ex_ssh_key_ids:
+            params['ssh_keys'] = ex_ssh_key_ids
+
+        private_networking = kwargs.get('private_networking', True)
+        params['private_networking'] = private_networking
+        headers = {'Content-type': 'application/json'}
+
+        data = self.connection.request('/droplets', data=json.dumps(params),
+                                       method='POST',
+                                       headers=headers).object['droplet']
+        if data.get('status') == 'ERROR':
+            raise Exception(data.get('message'))
+
+        return self._to_node(data=data)
+
+    def ex_start_node(self, node):
+        params = {"type": "power_on"}
+        res = self.connection.request('/droplets/%s/actions/' % node.id,
+                                      params=params, method='POST')
+        return res.status in [httplib.OK, httplib.CREATED, httplib.ACCEPTED]
+
+    def ex_stop_node(self, node):
+        params = {"type": "shutdown"}
+        res = self.connection.request('/droplets/%s/actions/' % node.id,
+                                      params=params, method='POST')
+        return res.status in [httplib.OK, httplib.CREATED, httplib.ACCEPTED]
+
+    def reboot_node(self, node):
+        params = {"type": "reboot"}
+        res = self.connection.request('/droplets/%s/actions/' % node.id,
+                                      params=params, method='POST')
+        return res.status in [httplib.OK, httplib.CREATED, httplib.ACCEPTED]
+
+    def destroy_node(self, node):
+        res = self.connection.request('/droplets/%s' % node.id,
+                                      method='DELETE')
+        return res.status in [httplib.OK, httplib.CREATED, httplib.ACCEPTED]
+
+    def ex_rename_node(self, node, name):
+        params = {"type": "rename", "name": name}
+        res = self.connection.request('/droplets/%s/actions/' % node.id,
+                                      params=params, method='POST')
+        return res.status in [httplib.OK, httplib.CREATED, httplib.ACCEPTED]
+
+    def ex_list_ssh_keys(self):
+        """
+        List all the available SSH keys.
+
+        :return: Available SSH keys.
+        :rtype: ``list`` of :class:`SSHKey`
+        """
+        data = self.connection.request('/account/keys').object['ssh_keys']
+        return list(map(self._to_ssh_key, data))
+
+    def ex_create_ssh_key(self, name, ssh_key_pub):
+        """
+        Create a new SSH key.
+
+        :param      name: Key name (required)
+        :type       name: ``str``
+
+        :param      name: Valid public key string (required)
+        :type       name: ``str``
+        """
+        params = {'name': name, 'public_key': ssh_key_pub}
+        data = self.connection.request('/account/keys', method='POST',
+                                       params=params).object
+        assert 'ssh_key' in data
+        return self._to_ssh_key(data=data['ssh_key'])
+
+    def ex_destroy_ssh_key(self, key_id):
+        """
+        Delete an existing SSH key.
+
+        :param      key_id: SSH key id (required)
+        :type       key_id: ``str``
+        """
+        res = self.connection.request('/account/keys/%s' % key_id,
+                                      method='DELETE')
+        return res.status == httplib.OK
+
+    def _to_node(self, data):
+        if 'status' in data:
+            state = self.NODE_STATE_MAP.get(data['status'], NodeState.UNKNOWN)
+        else:
+            state = NodeState.UNKNOWN
+
+        public_ips = []
+        private_ips = []
+        networks = data.get('networks', {})
+        
+        for network in networks.get('v4', []):
+            ip = network['ip_address']
+            if is_private_subnet(ip):
+                    private_ips.append(ip)
+            else:
+                    public_ips.append(ip)
+        extra_keys = ['name', 'image', 'backup_ids', 'features']
+        extra = {}
+        for key in extra_keys:
+            if key in data:
+                extra[key] = data[key]
+
+        node = Node(id=data['id'],
+                    name=data['name'],
+                    state=state,
+                    public_ips=public_ips,
+                    private_ips=private_ips,
+                    extra=extra,
+                    driver=self)
+        return node
+
+    def _to_image(self, data):
+        extra = {'distribution': data['distribution']}
+        return NodeImage(id=data['id'], name=data['name'], extra=extra,
+                         driver=self)
+
+    def _to_location(self, data):
+        location_id = data['slug']
+        name = data['name']
+        return NodeLocation(id=location_id, name=name, country=None,
+                            driver=self)
+
+    def _to_size(self, data):
+        size_id = data.get('slug')
+        name = size_id
+        ram = size_id
+        disk = "%sG SSD" % data.get('disk')
+        price = "$%s/hour, $%s/month" % (
+            data.get('price_hourly'), data.get('price_monthly'))
+        return NodeSize(id=size_id, name=name, ram=ram, disk=disk,
+                        bandwidth=0, price=price, driver=self)
+
+    def _to_ssh_key(self, data):
+        return SSHKey(id=data['id'], name=data['name'],
+                      pub_key=data.get('public_key', None))

--- a/libcloud/compute/providers.py
+++ b/libcloud/compute/providers.py
@@ -135,8 +135,8 @@ DRIVERS = {
     ('libcloud.compute.drivers.abiquo', 'AbiquoNodeDriver'),
     Provider.DIGITAL_OCEAN:
     ('libcloud.compute.drivers.digitalocean', 'DigitalOceanNodeDriver'),
-    Provider.DIGITAL_OCEAN2:
-    ('libcloud.compute.drivers.digitalocean', 'DigitalOcean2NodeDriver'),
+    Provider.DIGITAL_OCEAN_FIRST_GEN:
+    ('libcloud.compute.drivers.digitalocean', 'DigitalOceanFirstGenNodeDriver'),
     Provider.NEPHOSCALE:
     ('libcloud.compute.drivers.nephoscale', 'NephoscaleNodeDriver'),
     Provider.CLOUDFRAMES:

--- a/libcloud/compute/providers.py
+++ b/libcloud/compute/providers.py
@@ -135,6 +135,8 @@ DRIVERS = {
     ('libcloud.compute.drivers.abiquo', 'AbiquoNodeDriver'),
     Provider.DIGITAL_OCEAN:
     ('libcloud.compute.drivers.digitalocean', 'DigitalOceanNodeDriver'),
+    Provider.DIGITAL_OCEAN2:
+    ('libcloud.compute.drivers.digitalocean', 'DigitalOcean2NodeDriver'),
     Provider.NEPHOSCALE:
     ('libcloud.compute.drivers.nephoscale', 'NephoscaleNodeDriver'),
     Provider.CLOUDFRAMES:

--- a/libcloud/compute/types.py
+++ b/libcloud/compute/types.py
@@ -116,7 +116,7 @@ class Provider(object):
     HOSTVIRTUAL = 'hostvirtual'
     ABIQUO = 'abiquo'
     DIGITAL_OCEAN = 'digitalocean'
-    DIGITAL_OCEAN2 = 'digitalocean2'
+    DIGITAL_OCEAN_FIRST_GEN = 'digitalocean_first_gen'
     NEPHOSCALE = 'nephoscale'
     CLOUDFRAMES = 'cloudframes'
     EXOSCALE = 'exoscale'

--- a/libcloud/compute/types.py
+++ b/libcloud/compute/types.py
@@ -116,6 +116,7 @@ class Provider(object):
     HOSTVIRTUAL = 'hostvirtual'
     ABIQUO = 'abiquo'
     DIGITAL_OCEAN = 'digitalocean'
+    DIGITAL_OCEAN2 = 'digitalocean2'
     NEPHOSCALE = 'nephoscale'
     CLOUDFRAMES = 'cloudframes'
     EXOSCALE = 'exoscale'


### PR DESCRIPTION
adds support for DigitalOcean v2 API (current API, v1 is now deprecated). 

Provider.DIGITAL_OCEAN ('digitalocean') is now v2 API, while v1 is Provider.DIGITAL_OCEAN_FIRST_GEN ('digitalocean_first_gen')
